### PR TITLE
Prevent pokemon img from being dragged

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -23,7 +23,7 @@
     </div>
 
     <div class="scene" v-if="pokemon.id">
-      <img :src="'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/' + (pokemon.id) + '.png'" :class="{ 'pokemon': true, 'active': win, 'disappear': !intents && !pokemon.active }" />
+      <img :src="'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/' + (pokemon.id) + '.png'" :class="{ 'pokemon': true, 'active': win, 'disappear': !intents && !pokemon.active }" draggable="false"/>
     </div>
 
     <div v-if="intents && !pokemon.active">


### PR DESCRIPTION
Sí, verás... es que vi que se podia arrastrar la imagen y se veia al Pokemon® sin el filtro :(

He añadido a la imagen la propiedad _draggable="false"_, ¡con un impresionante soporte del **97.55%** según caniuse.com! - aunque igual habría sido mejor usar la propiedad _pointer-events: none;_, pero bueno.

Espero que este cambio sea digno del proyecto.

Love,
Dani :)